### PR TITLE
Add jupyterlab-a11y-checker and bump matplotlib/ydata-profile in data100 image

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -37,7 +37,7 @@ dependencies:
   - jupyterlab-favorites==3.2.2
   - jupyterlab_server==2.28.0
   - jupyterlab_widgets==3.0.15
-  - matplotlib==3.10.3
+  - matplotlib==3.10.0
   - mdit-py-plugins==0.4.2
   - ml_dtypes==0.4.0
   - mlxtend==0.23.4

--- a/environment.yml
+++ b/environment.yml
@@ -37,8 +37,7 @@ dependencies:
   - jupyterlab-favorites==3.2.2
   - jupyterlab_server==2.28.0
   - jupyterlab_widgets==3.0.15
-  - libclang==18.1.1
-  - matplotlib==3.9.1
+  - matplotlib==3.10.3
   - mdit-py-plugins==0.4.2
   - ml_dtypes==0.4.0
   - mlxtend==0.23.4

--- a/environment.yml
+++ b/environment.yml
@@ -38,7 +38,7 @@ dependencies:
   - jupyterlab_server==2.28.0
   - jupyterlab_widgets==3.0.15
   - libclang==18.1.1
-  - matplotlib==3.9.2
+  - matplotlib==3.9.1
   - mdit-py-plugins==0.4.2
   - ml_dtypes==0.4.0
   - mlxtend==0.23.4
@@ -57,7 +57,7 @@ dependencies:
   - tensorboard==2.17.1
   - tensorflow-cpu==2.17.0
   - tf-keras==2.17.0
-  - ydata-profiling==4.16.1
+  - ydata-profiling==4.18.0
 
   # Spring 2024 data 100
   - cpuonly==2.0
@@ -85,3 +85,6 @@ dependencies:
 
     # https://github.com/berkeley-dsep-infra/datahub/issues/7611
     - otter-pensieve==1.6.0
+
+    # Spring 2026, https://github.com/berkeley-dsep-infra/datahub/issues/8086
+    - jupyterlab-a11y-checker==0.2.6


### PR DESCRIPTION
I couldn't get the data100 image to build locally (I don't think I have any environment issues). I had to bump `ydata-profiling` and `matplotlib` packages since they were causing dependency issues.

Ref: https://github.com/berkeley-dsep-infra/datahub/issues/8086